### PR TITLE
Fix btn-link styling

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -28,7 +28,7 @@ a {
     letter-spacing: .5px;
 }
 
-.btn {
+.btn:not(.btn-link) {
     border-radius: 0;
     box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.24), 0px 0px 2px rgba(0, 0, 0, 0.15);
 }


### PR DESCRIPTION
Don't apply box-shadow to `.btn-link` so that it still works/looks as bootstrap inteded