### PR TITLE
No underline for btn-link:hover

### DIFF
--- a/scss/theme.scss
+++ b/scss/theme.scss
@@ -28,7 +28,9 @@
 }
 
 .btn-link:hover,
-a:hover {
+.btn-link:focus,
+a:hover,
+a:focus {
   text-decoration: none;
 }
 


### PR DESCRIPTION
![Screenshot from 2019-12-19 18-05-26](https://user-images.githubusercontent.com/11532135/71224395-8b880580-228a-11ea-858a-c22b5b27aa93.png)
To prevent this